### PR TITLE
Clarify scheduler polling interval

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -268,7 +268,7 @@ router_settings:
 | allowed_fails_policy | object | Specifies the number of allowed failures for different error types before cooling down a deployment. [More information here](reliability) |
 | default_max_parallel_requests | Optional[int] | The default maximum number of parallel requests for a deployment. |
 | default_priority | (Optional[int]) | The default priority for a request. Only for '.scheduler_acompletion()'. Default is None. | 
-| polling_interval | (Optional[float]) | frequency of polling queue. Only for '.scheduler_acompletion()'. Default is 3ms. |
+| polling_interval | (Optional[float]) | frequency of polling queue. Only for '.scheduler_acompletion()'. Default is 30ms. |
 | max_fallbacks | Optional[int] | The maximum number of fallbacks to try before exiting the call. Defaults to 5. |
 | default_litellm_params | Optional[dict] | The default litellm parameters to add to all requests (e.g. `temperature`, `max_tokens`). |
 | timeout | Optional[float] | The default timeout for a request. Default is 10 minutes. |

--- a/docs/my-website/docs/scheduler.md
+++ b/docs/my-website/docs/scheduler.md
@@ -42,7 +42,7 @@ router = Router(
     ],
     timeout=2, # timeout request if takes > 2s
     routing_strategy="usage-based-routing-v2",
-    polling_interval=0.03 # poll queue every 3ms if no healthy deployments
+    polling_interval=0.03 # poll queue every 30ms if no healthy deployments
 )
 
 try:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -270,7 +270,7 @@ class Router:
             cache_kwargs (dict): Additional kwargs to pass to RedisCache. Defaults to {}.
             caching_groups (Optional[List[tuple]]): List of model groups for caching across model groups. Defaults to None.
             client_ttl (int): Time-to-live for cached clients in seconds. Defaults to 3600.
-            polling_interval: (Optional[float]): frequency of polling queue. Only for '.scheduler_acompletion()'. Default is 3ms.
+            polling_interval: (Optional[float]): frequency of polling queue. Only for '.scheduler_acompletion()'. Default is 0.03s (30ms).
             default_priority: (Optional[int]): the default priority for a request. Only for '.scheduler_acompletion()'. Default is None.
             num_retries (Optional[int]): Number of retries for failed requests. Defaults to 2.
             timeout (Optional[float]): Timeout for requests. Defaults to None.
@@ -1586,7 +1586,7 @@ class Router:
         ## POLL QUEUE
         end_time = time.time() + self.timeout
         curr_time = time.time()
-        poll_interval = self.scheduler.polling_interval  # poll every 3ms
+        poll_interval = self.scheduler.polling_interval  # poll every 0.03s (30ms)
         make_request = False
 
         while curr_time < end_time:
@@ -1648,7 +1648,7 @@ class Router:
         ## POLL QUEUE
         end_time = time.time() + self.timeout
         curr_time = time.time()
-        poll_interval = self.scheduler.polling_interval  # poll every 3ms
+        poll_interval = self.scheduler.polling_interval  # poll every 0.03s (30ms)
         make_request = False
 
         while curr_time < end_time:

--- a/litellm/scheduler.py
+++ b/litellm/scheduler.py
@@ -31,7 +31,7 @@ class Scheduler:
         redis_cache: Optional[RedisCache] = None,
     ):
         """
-        polling_interval: float or null - frequency of polling queue. Default is 3ms.
+        polling_interval: float or null - frequency of polling queue. Default is 0.03s (30ms).
         """
         self.queue: list = []
         default_in_memory_ttl: Optional[float] = None
@@ -43,7 +43,7 @@ class Scheduler:
         )
         self.polling_interval = (
             polling_interval or DEFAULT_POLLING_INTERVAL
-        )  # default to 3ms
+        )  # default to 0.03s (30ms)
 
     async def add_request(self, request: FlowItem):
         # We use the priority directly, as lower values indicate higher priority


### PR DESCRIPTION
## Summary
- clarify that 0.03s equals 30ms in scheduler and router docs
- update code comments in `scheduler.py` and `router.py`
- keep documentation consistent

## Testing
- `pre-commit run --files litellm/scheduler.py litellm/router.py` *(fails: pyright errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684ab011aaf4832f82be7e7fb47b7092