### PR TITLE
fix: reject malformed Azure surrogate payloads

### DIFF
--- a/litellm/litellm_core_utils/llm_request_utils.py
+++ b/litellm/litellm_core_utils/llm_request_utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import litellm
 
@@ -28,6 +28,42 @@ def _ensure_extra_body_is_safe(extra_body: Optional[Dict]) -> Optional[Dict]:
                 extra_body["metadata"]["prompt"] = _prompt.__dict__
 
     return extra_body
+
+
+def contains_surrogate_code_point(value: str) -> bool:
+    return any(0xD800 <= ord(char) <= 0xDFFF for char in value)
+
+
+def find_surrogate_code_point_path(
+    value: Any,
+    path: str = "payload",
+) -> Optional[str]:
+    if isinstance(value, str):
+        if contains_surrogate_code_point(value):
+            return path
+        return None
+
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            nested_path = find_surrogate_code_point_path(
+                nested_value,
+                path=f"{path}.{key}",
+            )
+            if nested_path is not None:
+                return nested_path
+        return None
+
+    if isinstance(value, list):
+        for index, nested_value in enumerate(value):
+            nested_path = find_surrogate_code_point_path(
+                nested_value,
+                path=f"{path}[{index}]",
+            )
+            if nested_path is not None:
+                return nested_path
+        return None
+
+    return None
 
 
 def pick_cheapest_chat_models_from_llm_provider(custom_llm_provider: str, n=1):

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -41,6 +41,7 @@ from .common_utils import (
     get_azure_ad_token_from_oidc,
     process_azure_headers,
     select_azure_base_url_or_endpoint,
+    validate_azure_request_payload,
 )
 from .image_generation import get_azure_image_generation_config
 
@@ -143,6 +144,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         - call chat.completions.create.with_raw_response when litellm.return_response_headers is True
         - call chat.completions.create by default
         """
+        validate_azure_request_payload(data)
         try:
             raw_response = azure_client.chat.completions.with_raw_response.create(
                 **data, timeout=timeout
@@ -168,6 +170,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         - call chat.completions.create by default
         """
         start_time = time.time()
+        validate_azure_request_payload(data)
         try:
             raw_response = await azure_client.chat.completions.with_raw_response.create(
                 **data, timeout=timeout
@@ -307,6 +310,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 )
             else:
                 ## LOGGING
+                validate_azure_request_payload(data)
                 logging_obj.pre_call(
                     input=messages,
                     api_key=api_key,
@@ -417,6 +421,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     "Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI"
                 )
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["messages"],
                 api_key=azure_client.api_key,
@@ -544,6 +549,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 message="azure_client is not an instance of AzureOpenAI or OpenAI",
             )
         ## LOGGING
+        validate_azure_request_payload(data)
         logging_obj.pre_call(
             input=data["messages"],
             api_key=azure_client.api_key,
@@ -602,6 +608,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 )
 
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["messages"],
                 api_key=azure_client.api_key,
@@ -668,6 +675,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
     ) -> EmbeddingResponse:
         response = None
         try:
+            validate_azure_request_payload(data)
             openai_aclient = self.get_azure_openai_client(
                 api_version=api_version,
                 api_base=api_base,
@@ -771,6 +779,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if max_retries is None:
                 max_retries = litellm.DEFAULT_MAX_RETRIES
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=input,
                 api_key=api_key,
@@ -825,7 +834,12 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 original_response=response,
             )
 
-            return convert_to_model_response_object(response_object=response.model_dump(), model_response_object=model_response, response_type="embedding", _response_headers=process_azure_headers(headers))  # type: ignore
+            return convert_to_model_response_object(
+                response_object=response.model_dump(),
+                model_response_object=model_response,
+                response_type="embedding",
+                _response_headers=process_azure_headers(headers),
+            )  # type: ignore
         except AzureOpenAIError as e:
             raise e
         except Exception as e:
@@ -855,6 +869,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         Alternative to needing a custom transport implementation
         """
+        validate_azure_request_payload(data)
         if client is None:
             _params = {}
             if timeout is not None:
@@ -969,6 +984,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
 
         Alternative to needing a custom transport implementation
         """
+        validate_azure_request_payload(data)
         if client is None:
             _params = {}
             if timeout is not None:
@@ -1252,7 +1268,18 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 is_async=False,
             )
             if aimg_generation is True:
-                return self.aimage_generation(data=data, input=input, logging_obj=logging_obj, model_response=model_response, api_key=api_key, client=client, azure_client_params=azure_client_params, timeout=timeout, headers=headers, model=model)  # type: ignore
+                return self.aimage_generation(
+                    data=data,
+                    input=input,
+                    logging_obj=logging_obj,
+                    model_response=model_response,
+                    api_key=api_key,
+                    client=client,
+                    azure_client_params=azure_client_params,
+                    timeout=timeout,
+                    headers=headers,
+                    model=model,
+                )  # type: ignore
 
             # Use the deployment name (model) for URL construction, not the base_model from data
             img_gen_api_base = self.create_azure_base_url(
@@ -1288,7 +1315,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 original_response=response,
             )
             # return response
-            return convert_to_model_response_object(response_object=response, model_response_object=model_response, response_type="image_generation")  # type: ignore
+            return convert_to_model_response_object(
+                response_object=response,
+                model_response_object=model_response,
+                response_type="image_generation",
+            )  # type: ignore
         except AzureOpenAIError as e:
             raise e
         except Exception as e:

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -8,6 +8,9 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 import litellm
 from litellm._logging import verbose_logger
 from litellm.caching.caching import DualCache
+from litellm.litellm_core_utils.llm_request_utils import (
+    find_surrogate_code_point_path,
+)
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.openai.common_utils import BaseOpenAILLM
 from litellm.secret_managers.get_azure_ad_token_provider import (
@@ -38,6 +41,24 @@ class AzureOpenAIError(BaseLLMException):
             headers=headers,
             body=body,
         )
+
+
+def validate_azure_request_payload(
+    payload: Any,
+    payload_name: str = "azure_request",
+) -> None:
+    surrogate_path = find_surrogate_code_point_path(payload, path=payload_name)
+    if surrogate_path is None:
+        return
+
+    raise AzureOpenAIError(
+        status_code=400,
+        message=(
+            "Invalid Unicode surrogate code point found in "
+            f"{surrogate_path}. Please replace truncated surrogate "
+            "characters with valid Unicode before calling Azure."
+        ),
+    )
 
 
 def process_azure_headers(headers: Union[httpx.Headers, dict]) -> dict:

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -6,7 +6,11 @@ from litellm.litellm_core_utils.prompt_templates.factory import prompt_factory
 from litellm.utils import CustomStreamWrapper, ModelResponse, TextCompletionResponse
 
 from ...openai.completion.transformation import OpenAITextCompletionConfig
-from ..common_utils import AzureOpenAIError, BaseAzureLLM
+from ..common_utils import (
+    AzureOpenAIError,
+    BaseAzureLLM,
+    validate_azure_request_payload,
+)
 
 openai_text_completion_config = OpenAITextCompletionConfig()
 
@@ -126,6 +130,7 @@ class AzureTextCompletion(BaseAzureLLM):
                 )
             else:
                 ## LOGGING
+                validate_azure_request_payload(data)
                 logging_obj.pre_call(
                     input=prompt,
                     api_key=api_key,
@@ -229,6 +234,7 @@ class AzureTextCompletion(BaseAzureLLM):
                 )
 
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["prompt"],
                 api_key=azure_client.api_key,
@@ -294,6 +300,7 @@ class AzureTextCompletion(BaseAzureLLM):
             )
 
         ## LOGGING
+        validate_azure_request_payload(data)
         logging_obj.pre_call(
             input=data["prompt"],
             api_key=azure_client.api_key,
@@ -346,6 +353,7 @@ class AzureTextCompletion(BaseAzureLLM):
                     message="azure_client is not an instance of AsyncAzureOpenAI",
                 )
             ## LOGGING
+            validate_azure_request_payload(data)
             logging_obj.pre_call(
                 input=data["prompt"],
                 api_key=azure_client.api_key,

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -6,6 +6,9 @@ import orjson
 from fastapi import Request, UploadFile, status
 
 from litellm._logging import verbose_proxy_logger
+from litellm.litellm_core_utils.llm_request_utils import (
+    find_surrogate_code_point_path,
+)
 from litellm.proxy._types import ProxyException
 from litellm.proxy.common_utils.callback_utils import (
     get_metadata_variable_name_from_kwargs,
@@ -79,6 +82,22 @@ async def _read_request_body(request: Optional[Request]) -> Dict:
                             param="request_body",
                             code=status.HTTP_400_BAD_REQUEST,
                         )
+
+        surrogate_path = find_surrogate_code_point_path(
+            parsed_body,
+            path="request_body",
+        )
+        if surrogate_path is not None:
+            raise ProxyException(
+                message=(
+                    "Invalid Unicode surrogate code point found in "
+                    f"{surrogate_path}. Please replace truncated surrogate "
+                    "characters with valid Unicode before retrying."
+                ),
+                type="invalid_request_error",
+                param="request_body",
+                code=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Cache the parsed result
         _safe_set_request_parsed_body(request=request, parsed_body=parsed_body)
@@ -197,10 +216,10 @@ def check_file_size_under_limit(
 
     if llm_router is not None and request_data["model"] in router_model_names:
         try:
-            deployment: Optional[
-                Deployment
-            ] = llm_router.get_deployment_by_model_group_name(
-                model_group_name=request_data["model"]
+            deployment: Optional[Deployment] = (
+                llm_router.get_deployment_by_model_group_name(
+                    model_group_name=request_data["model"]
+                )
             )
             if (
                 deployment
@@ -257,7 +276,7 @@ async def get_form_data(request: Request) -> Dict[str, Any]:
 
 
 async def convert_upload_files_to_file_data(
-    form_data: Dict[str, Any]
+    form_data: Dict[str, Any],
 ) -> Dict[str, Any]:
     """
     Convert FastAPI UploadFile objects to file data tuples for litellm.

--- a/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
+++ b/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
@@ -12,6 +12,8 @@ sys.path.insert(
 import litellm
 from litellm.exceptions import ContentPolicyViolationError
 from litellm.litellm_core_utils.exception_mapping_utils import exception_type
+from litellm.llms.azure.azure import AzureChatCompletion
+from litellm.llms.azure.common_utils import AzureOpenAIError
 
 
 class TestAzureExceptionMapping:
@@ -19,58 +21,45 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_innererror_access(self):
         """Test that Azure content policy violation exceptions provide access to innererror details"""
-        
+
         # Create a mock Azure OpenAI exception with body containing innererror
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = {
             "innererror": {
                 "code": "ResponsibleAIPolicyViolation",
                 "content_filter_result": {
-                    "hate": {
-                        "filtered": True,
-                        "severity": "high"
-                    },
-                    "jailbreak": {
-                        "filtered": False,
-                        "detected": False
-                    },
-                    "self_harm": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "sexual": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "violence": {
-                        "filtered": True,
-                        "severity": "medium"
-                    }
-                }
+                    "hate": {"filtered": True, "severity": "high"},
+                    "jailbreak": {"filtered": False, "detected": False},
+                    "self_harm": {"filtered": False, "severity": "safe"},
+                    "sexual": {"filtered": False, "severity": "safe"},
+                    "violence": {"filtered": True, "severity": "medium"},
+                },
             }
         }
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Access the exception and verify provider_specific_fields
         e = exc_info.value
         assert e.provider_specific_fields is not None
         assert "innererror" in e.provider_specific_fields
-        
+
         innererror = e.provider_specific_fields["innererror"]
         assert innererror["code"] == "ResponsibleAIPolicyViolation"
         assert "content_filter_result" in innererror
-        
+
         content_filter_result = innererror["content_filter_result"]
         assert content_filter_result["hate"]["filtered"] is True
         assert content_filter_result["hate"]["severity"] == "high"
@@ -82,61 +71,48 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_different_categories(self):
         """Test Azure content policy violation with different filtering categories"""
-        
-        # Mock exception with different content filter results  
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+
+        # Mock exception with different content filter results
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = {
             "innererror": {
                 "code": "ResponsibleAIPolicyViolation",
                 "content_filter_result": {
-                    "hate": {
-                        "filtered": False,
-                        "severity": "safe"
-                    },
-                    "jailbreak": {
-                        "filtered": True,
-                        "detected": True
-                    },
-                    "self_harm": {
-                        "filtered": True,
-                        "severity": "high"
-                    },
-                    "sexual": {
-                        "filtered": True,
-                        "severity": "medium"
-                    },
-                    "violence": {
-                        "filtered": False,
-                        "severity": "safe"
-                    }
-                }
+                    "hate": {"filtered": False, "severity": "safe"},
+                    "jailbreak": {"filtered": True, "detected": True},
+                    "self_harm": {"filtered": True, "severity": "high"},
+                    "sexual": {"filtered": True, "severity": "medium"},
+                    "violence": {"filtered": False, "severity": "safe"},
+                },
             }
         }
-        
+
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly with different violation type
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify provider_specific_fields contains the expected innererror structure
         e = exc_info.value
         assert e.provider_specific_fields is not None
         print("got provider_specific_fields=", e.provider_specific_fields)
         innererror = e.provider_specific_fields["innererror"]
         content_filter_result = innererror["content_filter_result"]
-        
+
         # Check different filter categories
         assert content_filter_result["sexual"]["filtered"] is True
         assert content_filter_result["sexual"]["severity"] == "medium"
         assert content_filter_result["self_harm"]["filtered"] is True
-        assert content_filter_result["self_harm"]["severity"] == "high" 
+        assert content_filter_result["self_harm"]["severity"] == "high"
         assert content_filter_result["jailbreak"]["filtered"] is True
         assert content_filter_result["jailbreak"]["detected"] is True
         assert content_filter_result["hate"]["filtered"] is False
@@ -144,22 +120,24 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_missing_innererror(self):
         """Test Azure content policy violation when innererror is missing from response"""
-        
+
         # Mock exception without body attribute
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
         # Note: no mock_exception.body attribute set
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify that even without innererror, the exception is still raised properly
         e = exc_info.value
         print("got exception=", e)
@@ -169,28 +147,30 @@ class TestAzureExceptionMapping:
 
     def test_azure_content_policy_violation_non_dict_body(self):
         """Test Azure content policy violation when body is not a dictionary"""
-        
+
         # Mock exception with non-dict body
-        mock_exception = Exception("The response was filtered due to the prompt triggering Azure OpenAI's content management policy")
+        mock_exception = Exception(
+            "The response was filtered due to the prompt triggering Azure OpenAI's content management policy"
+        )
         mock_exception.body = "invalid body format"
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
-        
+
         # Test the exception mapping directly
         with pytest.raises(ContentPolicyViolationError) as exc_info:
             exception_type(
                 model="azure/gpt-4",
                 original_exception=mock_exception,
-                custom_llm_provider="azure"
+                custom_llm_provider="azure",
             )
-        
+
         # Verify that with invalid body format, innererror should be None
         e = exc_info.value
         print("got exception=", e)
         print("exception fields=", vars(e))
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields.get("innererror") is None 
+        assert e.provider_specific_fields.get("innererror") is None
 
     def test_azure_images_content_policy_violation_preserves_nested_inner_error(self):
         """Azure Images endpoints return errors nested under body['error'] with inner_error.
@@ -237,9 +217,17 @@ class TestAzureExceptionMapping:
 
         # Provider-specific nested details must be preserved
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields["inner_error"]["code"] == "ResponsibleAIPolicyViolation"
+        assert (
+            e.provider_specific_fields["inner_error"]["code"]
+            == "ResponsibleAIPolicyViolation"
+        )
         assert e.provider_specific_fields["inner_error"]["revised_prompt"] == "revised"
-        assert e.provider_specific_fields["inner_error"]["content_filter_results"]["violence"]["filtered"] is True
+        assert (
+            e.provider_specific_fields["inner_error"]["content_filter_results"][
+                "violence"
+            ]["filtered"]
+            is True
+        )
 
     def test_azure_content_policy_violation_detected_via_inner_error_code(self):
         """Regression test for #20811: Azure returns inner_error with
@@ -263,8 +251,7 @@ class TestAzureExceptionMapping:
                         "violence": {"filtered": True, "severity": "low"},
                     },
                     "revised_prompt": (
-                        "A dark and intense illustration of a man "
-                        "in a dramatic action scene."
+                        "A dark and intense illustration of a man in a dramatic action scene."
                     ),
                 },
                 "message": (
@@ -327,7 +314,10 @@ class TestAzureExceptionMapping:
 
         e = exc_info.value
         assert e.provider_specific_fields is not None
-        assert e.provider_specific_fields["inner_error"]["code"] == "ResponsibleAIPolicyViolation"
+        assert (
+            e.provider_specific_fields["inner_error"]["code"]
+            == "ResponsibleAIPolicyViolation"
+        )
 
     def test_azure_image_polling_error_preserves_body(self):
         """Verify that AzureOpenAIError raised from the DALL-E polling path
@@ -423,9 +413,7 @@ class TestAzureExceptionMapping:
         """Test that OpenAI invalid_encrypted_content errors also get helpful guidance."""
         from litellm.exceptions import BadRequestError
 
-        mock_exception = Exception(
-            "The encrypted content could not be verified."
-        )
+        mock_exception = Exception("The encrypted content could not be verified.")
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_exception.response = mock_response
@@ -440,3 +428,22 @@ class TestAzureExceptionMapping:
         error = exc_info.value
         assert "encrypted_content_affinity" in error.message
         assert "enable_pre_call_checks" in error.message
+
+
+def test_azure_chat_request_rejects_lone_surrogates_before_send():
+    azure_chat_completion = AzureChatCompletion()
+    azure_client = MagicMock()
+
+    with pytest.raises(AzureOpenAIError) as exc_info:
+        azure_chat_completion.make_sync_azure_openai_chat_completion_request(
+            azure_client=azure_client,
+            data={
+                "model": "gpt-5.4",
+                "messages": [{"role": "user", "content": "\ud83e"}],
+            },
+            timeout=30,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "surrogate" in exc_info.value.message.lower()
+    azure_client.chat.completions.with_raw_response.create.assert_not_called()

--- a/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py
@@ -63,6 +63,25 @@ async def test_request_body_caching():
 
 
 @pytest.mark.asyncio
+async def test_request_body_rejects_escaped_lone_surrogates():
+    """Escaped lone surrogates should fail fast as invalid request bodies."""
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(
+        return_value=b'{"messages": [{"role": "user", "content": "\\ud83e"}]}'
+    )
+    mock_request.headers = {"content-type": "application/json"}
+    mock_request.scope = {}
+    mock_request.state._cached_headers = None
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _read_request_body(mock_request)
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.param == "request_body"
+    assert "surrogate" in exc_info.value.message.lower()
+
+
+@pytest.mark.asyncio
 async def test_form_data_parsing():
     """
     Test that form data is correctly parsed from the request.
@@ -99,25 +118,27 @@ async def test_form_data_parsing():
 async def test_form_data_with_json_metadata():
     """
     Test that form data with a JSON-encoded metadata field is correctly parsed.
-    
+
     When form data includes a 'metadata' field, it comes as a JSON string that needs
     to be parsed into a Python dictionary (lines 42-43 of http_parsing_utils.py).
     """
     # Create a mock request with form data containing JSON metadata
     mock_request = MagicMock()
-    
+
     # Metadata is sent as a JSON string in form data
-    metadata_json_string = json.dumps({
-        "user_id": "12345",
-        "request_type": "audio_transcription",
-        "tags": ["urgent", "production"],
-        "custom_field": {"nested": "value"}
-    })
-    
+    metadata_json_string = json.dumps(
+        {
+            "user_id": "12345",
+            "request_type": "audio_transcription",
+            "tags": ["urgent", "production"],
+            "custom_field": {"nested": "value"},
+        }
+    )
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": metadata_json_string  # This is a JSON string, not a dict
+        "metadata": metadata_json_string,  # This is a JSON string, not a dict
     }
 
     # Mock the form method to return the test data as an awaitable
@@ -136,11 +157,11 @@ async def test_form_data_with_json_metadata():
     assert result["metadata"]["request_type"] == "audio_transcription"
     assert result["metadata"]["tags"] == ["urgent", "production"]
     assert result["metadata"]["custom_field"] == {"nested": "value"}
-    
+
     # Verify other fields remain unchanged
     assert result["model"] == "whisper-1"
     assert result["file"] == "audio.mp3"
-    
+
     # Verify form() was called
     mock_request.form.assert_called_once()
 
@@ -149,16 +170,16 @@ async def test_form_data_with_json_metadata():
 async def test_form_data_with_invalid_json_metadata():
     """
     Test that form data with invalid JSON in metadata field raises an exception.
-    
+
     This tests error handling when the metadata field contains malformed JSON.
     """
     # Create a mock request with form data containing invalid JSON metadata
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": '{"invalid": json}'  # Invalid JSON - unquoted value
+        "metadata": '{"invalid": json}',  # Invalid JSON - unquoted value
     }
 
     # Mock the form method to return the test data
@@ -176,17 +197,13 @@ async def test_form_data_with_invalid_json_metadata():
 async def test_form_data_without_metadata():
     """
     Test that form data without metadata field works correctly.
-    
+
     Ensures the metadata parsing logic doesn't break when metadata is absent.
     """
     # Create a mock request with form data without metadata
     mock_request = MagicMock()
-    
-    test_data = {
-        "model": "whisper-1",
-        "file": "audio.mp3",
-        "language": "en"
-    }
+
+    test_data = {"model": "whisper-1", "file": "audio.mp3", "language": "en"}
 
     # Mock the form method to return the test data
     mock_request.form = AsyncMock(return_value=test_data)
@@ -212,11 +229,11 @@ async def test_form_data_with_empty_metadata():
     """
     # Create a mock request with form data containing empty metadata
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": "{}"  # Empty JSON object as string
+        "metadata": "{}",  # Empty JSON object as string
     }
 
     # Mock the form method to return the test data
@@ -239,22 +256,19 @@ async def test_form_data_with_empty_metadata():
 async def test_form_data_with_dict_metadata():
     """
     Test that form data with metadata already as a dict is not parsed again.
-    
+
     This handles edge cases where metadata might already be a dictionary
     (shouldn't happen in normal form data, but defensive coding).
     """
     # Create a mock request with form data where metadata is already a dict
     mock_request = MagicMock()
-    
-    metadata_dict = {
-        "user_id": "12345",
-        "tags": ["test"]
-    }
-    
+
+    metadata_dict = {"user_id": "12345", "tags": ["test"]}
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": metadata_dict  # Already a dict, not a string
+        "metadata": metadata_dict,  # Already a dict, not a string
     }
 
     # Mock the form method to return the test data
@@ -281,11 +295,11 @@ async def test_form_data_with_none_metadata():
     """
     # Create a mock request with form data where metadata is None
     mock_request = MagicMock()
-    
+
     test_data = {
         "model": "whisper-1",
         "file": "audio.mp3",
-        "metadata": None  # None value
+        "metadata": None,  # None value
     }
 
     # Mock the form method to return the test data
@@ -373,7 +387,7 @@ async def test_json_parsing_error_handling():
     """
     # Test case 1: Trailing comma error
     mock_request = MagicMock()
-    invalid_json_with_trailing_comma = b'''{
+    invalid_json_with_trailing_comma = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -385,8 +399,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request.body = AsyncMock(return_value=invalid_json_with_trailing_comma)
     mock_request.headers = {"content-type": "application/json"}
     mock_request.scope = {}
@@ -394,14 +408,14 @@ async def test_json_parsing_error_handling():
     # Should raise ProxyException for trailing comma
     with pytest.raises(ProxyException) as exc_info:
         await _read_request_body(mock_request)
-    
+
     assert exc_info.value.code == "400"
     assert "Invalid JSON payload" in exc_info.value.message
     assert "trailing comma" in exc_info.value.message
 
     # Test case 2: Unquoted property name error
     mock_request2 = MagicMock()
-    invalid_json_unquoted_property = b'''{
+    invalid_json_unquoted_property = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -410,8 +424,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request2.body = AsyncMock(return_value=invalid_json_unquoted_property)
     mock_request2.headers = {"content-type": "application/json"}
     mock_request2.scope = {}
@@ -419,13 +433,13 @@ async def test_json_parsing_error_handling():
     # Should raise ProxyException for unquoted property
     with pytest.raises(ProxyException) as exc_info2:
         await _read_request_body(mock_request2)
-    
+
     assert exc_info2.value.code == "400"
     assert "Invalid JSON payload" in exc_info2.value.message
 
     # Test case 3: Valid JSON should work normally
     mock_request3 = MagicMock()
-    valid_json = b'''{
+    valid_json = b"""{
         "model": "gpt-4o",
         "tools": [
             {
@@ -437,8 +451,8 @@ async def test_json_parsing_error_handling():
             }
         ],
         "input": "Run available tools"
-    }'''
-    
+    }"""
+
     mock_request3.body = AsyncMock(return_value=valid_json)
     mock_request3.headers = {"content-type": "application/json"}
     mock_request3.scope = {}
@@ -505,15 +519,10 @@ def test_get_tags_from_request_body_with_metadata_tags():
     """
     Test that tags are correctly extracted from request body metadata.
     """
-    request_body = {
-        "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", "tag2", "tag3"]
-        }
-    }
-    
+    request_body = {"model": "gpt-4", "metadata": {"tags": ["tag1", "tag2", "tag3"]}}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -523,13 +532,11 @@ def test_get_tags_from_request_body_with_litellm_metadata_tags():
     """
     request_body = {
         "model": "gpt-4",
-        "litellm_metadata": {
-            "tags": ["tag1", "tag2", "tag3"]
-        }
+        "litellm_metadata": {"tags": ["tag1", "tag2", "tag3"]},
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -537,13 +544,10 @@ def test_get_tags_from_request_body_with_root_tags():
     """
     Test that tags are correctly extracted from root level of request body.
     """
-    request_body = {
-        "model": "gpt-4",
-        "tags": ["tag1", "tag2"]
-    }
-    
+    request_body = {"model": "gpt-4", "tags": ["tag1", "tag2"]}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2"]
 
 
@@ -553,14 +557,12 @@ def test_get_tags_from_request_body_with_combined_tags():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", "tag2"]
-        },
-        "tags": ["tag3", "tag4"]
+        "metadata": {"tags": ["tag1", "tag2"]},
+        "tags": ["tag3", "tag4"],
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3", "tag4"]
 
 
@@ -570,13 +572,11 @@ def test_get_tags_from_request_body_filters_non_strings():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": {
-            "tags": ["tag1", 123, "tag2", None, "tag3", {"nested": "dict"}]
-        }
+        "metadata": {"tags": ["tag1", 123, "tag2", None, "tag3", {"nested": "dict"}]},
     }
-    
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == ["tag1", "tag2", "tag3"]
 
 
@@ -584,13 +584,10 @@ def test_get_tags_from_request_body_no_tags():
     """
     Test that empty list is returned when no tags are present.
     """
-    request_body = {
-        "model": "gpt-4",
-        "metadata": {}
-    }
-    
+    request_body = {"model": "gpt-4", "metadata": {}}
+
     result = get_tags_from_request_body(request_body=request_body)
-    
+
     assert result == []
 
 
@@ -601,18 +598,13 @@ def test_get_tags_from_request_body_with_dict_tags():
     """
     request_body = {
         "model": "aws/anthropic/bedrock-claude-3-5-sonnet-v1",
-        "messages": [
-            {
-                "role": "user",
-                "content": "aloha"
-            }
-        ],
+        "messages": [{"role": "user", "content": "aloha"}],
         "metadata": {
             "tags": {
                 "litellm_id": "litellm_ratelimit_test",
-                "llm_id": "llmid_ratelimit_test"
+                "llm_id": "llmid_ratelimit_test",
             }
-        }
+        },
     }
 
     result = get_tags_from_request_body(request_body=request_body)
@@ -631,7 +623,7 @@ def test_get_tags_from_request_body_with_null_metadata():
     """
     request_body = {
         "model": "gpt-4",
-        "metadata": None  # OpenAI API accepts metadata: null
+        "metadata": None,  # OpenAI API accepts metadata: null
     }
 
     result = get_tags_from_request_body(request_body=request_body)
@@ -648,10 +640,7 @@ def test_populate_request_with_path_params_adds_query_params():
     # Create a mock request with query parameters
     mock_request = MagicMock()
     # Mock query_params as a dict-like object that can be converted to dict
-    mock_request.query_params = {
-        "organization_id": "org-123",
-        "user_id": "user-456"
-    }
+    mock_request.query_params = {"organization_id": "org-123", "user_id": "user-456"}
     mock_request.path_params = {}
     # Mock url.path to avoid errors in _add_vector_store_id_from_path
     mock_request.url.path = "/v1/chat/completions"
@@ -659,7 +648,7 @@ def test_populate_request_with_path_params_adds_query_params():
     # Initial request data without query params
     request_data = {
         "model": "gpt-4",
-        "messages": [{"role": "user", "content": "Hello"}]
+        "messages": [{"role": "user", "content": "Hello"}],
     }
 
     # Call the function
@@ -683,7 +672,7 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
     # Mock query_params as a dict-like object that can be converted to dict
     mock_request.query_params = {
         "organization_id": "org-query-param",
-        "model": "gpt-3.5-turbo"
+        "model": "gpt-3.5-turbo",
     }
     mock_request.path_params = {}
     # Mock url.path to avoid errors in _add_vector_store_id_from_path
@@ -693,7 +682,7 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
     request_data = {
         "model": "gpt-4",  # This should NOT be overwritten
         "organization_id": "org-existing",  # This should NOT be overwritten
-        "messages": [{"role": "user", "content": "Hello"}]
+        "messages": [{"role": "user", "content": "Hello"}],
     }
 
     # Call the function
@@ -701,7 +690,9 @@ def test_populate_request_with_path_params_does_not_overwrite_existing_values():
 
     # Verify existing values were NOT overwritten
     assert result["model"] == "gpt-4"  # Should keep original, not "gpt-3.5-turbo"
-    assert result["organization_id"] == "org-existing"  # Should keep original, not "org-query-param"
+    assert (
+        result["organization_id"] == "org-existing"
+    )  # Should keep original, not "org-query-param"
     # Verify other data is preserved
     assert result["messages"] == [{"role": "user", "content": "Hello"}]
 
@@ -776,12 +767,18 @@ def test_safe_get_request_headers_caches_on_request_state():
     and returns the same object on subsequent calls.
     """
     mock_request = MagicMock()
-    mock_request.headers = {"content-type": "application/json", "authorization": "Bearer sk-123"}
+    mock_request.headers = {
+        "content-type": "application/json",
+        "authorization": "Bearer sk-123",
+    }
     mock_request.state = MagicMock(spec=[])  # empty spec so getattr returns default
 
     # First call — should create and cache
     result1 = _safe_get_request_headers(mock_request)
-    assert result1 == {"content-type": "application/json", "authorization": "Bearer sk-123"}
+    assert result1 == {
+        "content-type": "application/json",
+        "authorization": "Bearer sk-123",
+    }
     assert mock_request.state._cached_headers is result1
 
     # Second call — should return the cached object (same identity)
@@ -821,8 +818,10 @@ def test_safe_get_request_headers_state_unavailable():
     Test that _safe_get_request_headers still returns headers when
     request.state rejects attribute writes (the except path on the cache-write).
     """
+
     class ReadOnlyState:
         """State object that allows reads but raises on writes."""
+
         def __setattr__(self, name, value):
             raise AttributeError("read-only state")
 

--- a/tests/test_litellm/test_router_retry_non_retryable_errors.py
+++ b/tests/test_litellm/test_router_retry_non_retryable_errors.py
@@ -16,6 +16,7 @@ import pytest
 
 import litellm
 from litellm import Router
+from litellm.llms.azure.common_utils import AzureOpenAIError
 
 
 def _make_rate_limit_error(message="Rate limited"):
@@ -112,16 +113,57 @@ async def test_non_retryable_error_in_retry_loop_raises_immediately():
         else:
             raise context_window_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.ContextWindowExceededError):
             await router.async_function_with_retries(
                 num_retries=2,
                 **_base_kwargs(),
             )
+
+
+@pytest.mark.asyncio
+async def test_azure_400_with_surrogate_unicode_fails_fast():
+    """
+    Verify that AzureOpenAIError(status_code=400) containing surrogate Unicode fails fast
+    and does not retry, even when the router sees the raw provider exception.
+    """
+    router = _create_router(num_retries=2)
+
+    call_count = 0
+
+    async def mock_make_call(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise AzureOpenAIError(
+            status_code=400, message="Bad request with surrogate: \ud83d"
+        )
+
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
+        with pytest.raises(AzureOpenAIError):
+            await router.async_function_with_retries(
+                num_retries=2,
+                **_base_kwargs(),
+            )
+
+        assert call_count == 1
 
 
 @pytest.mark.asyncio
@@ -145,11 +187,16 @@ async def test_bad_request_error_in_retry_loop_raises_immediately():
         else:
             raise bad_request_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.BadRequestError):
             await router.async_function_with_retries(
                 num_retries=2,
@@ -172,11 +219,16 @@ async def test_original_exception_updated_to_latest_error():
         call_count += 1
         raise _make_rate_limit_error(f"Rate limit attempt {call_count}")
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.RateLimitError) as exc_info:
             await router.async_function_with_retries(
                 num_retries=2,
@@ -201,11 +253,16 @@ async def test_retryable_errors_still_retry_normally():
         call_count += 1
         raise _make_rate_limit_error(f"Rate limit attempt {call_count}")
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.RateLimitError):
             await router.async_function_with_retries(
                 num_retries=3,
@@ -236,11 +293,16 @@ async def test_not_found_error_in_retry_loop_raises_immediately():
         else:
             raise not_found_error
 
-    with patch.object(router, "make_call", side_effect=mock_make_call), \
-         patch.object(router, "_async_get_healthy_deployments",
-                      return_value=(["d1", "d2"], ["d1", "d2"])), \
-         patch.object(router, "_time_to_sleep_before_retry", return_value=0), \
-         patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs):
+    with (
+        patch.object(router, "make_call", side_effect=mock_make_call),
+        patch.object(
+            router,
+            "_async_get_healthy_deployments",
+            return_value=(["d1", "d2"], ["d1", "d2"]),
+        ),
+        patch.object(router, "_time_to_sleep_before_retry", return_value=0),
+        patch.object(router, "log_retry", side_effect=lambda kwargs, e: kwargs),
+    ):
         with pytest.raises(litellm.NotFoundError):
             await router.async_function_with_retries(
                 num_retries=2,


### PR DESCRIPTION
## Relevant issues

Fixes BerriAI/litellm#23959

## Stack

- base branch: `test-google-interactions-openapi-refs`
- issue diff stays isolated to the Azure surrogate validation fix while branch CI unblocks land underneath it in separate PRs

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

- reject lone surrogate Unicode code points in Azure request payloads before transport dispatch
- reject escaped lone surrogates at proxy request parsing time with a 400 `request_body` error
- add regression coverage for Azure preflight validation, proxy parsing, and router fail-fast retry behavior

## Verification

- `poetry run pytest tests/test_litellm/llms/azure/test_azure_exception_mapping.py tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py tests/test_litellm/test_router_retry_non_retryable_errors.py -v` -> `46 passed`
- fork workflow: https://github.com/seonghobae/litellm/actions/runs/23420494895
