### PR TITLE
docs: add canonical delivery guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ When opening issues or pull requests, follow these templates:
 - Update provider documentation when adding new providers
 - Include code examples for new features
 - Update changelog and release notes
+- Repository-canonical engineering and workflow docs live under `docs/engineering/`, `docs/workflow/`, `docs/agents/`, and `docs/coderabbit/`.
 
 ## SECURITY CONSIDERATIONS
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # LiteLLM Architecture - LiteLLM SDK + AI Gateway
 
+## Canonical Delivery Docs
+
+- Repository-canonical delivery and verification docs live under `docs/engineering/`, `docs/workflow/`, `docs/agents/`, and `docs/coderabbit/`.
+- These docs complement `AGENTS.md` by recording the active acceptance, harness, and PR continuity rules used to ship focused fixes such as `BerriAI/litellm#23959`.
+
 This document helps contributors understand where to make changes in LiteLLM.
 
 ---

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,17 @@
+# Agents README
+
+This file is the repository-canonical guide for agent-driven work in LiteLLM.
+
+## Primary Sources
+
+- `AGENTS.md` remains the broad repository instruction file.
+- `docs/engineering/acceptance-criteria.md` defines when a task is actually done.
+- `docs/engineering/harness-engineering.md` defines the canonical verification commands.
+- `docs/workflow/one-day-delivery-plan.md` and `docs/workflow/pr-continuity.md` define branch and PR handling.
+
+## Working Rules
+
+- Use the narrowest existing tests for issue-scoped fixes before running broader suites.
+- Keep branch-specific CI unblockers separate from the main functional fix when possible.
+- Reuse the existing branch and canonical PR for the task instead of creating duplicates.
+- Treat AI review findings as actionable inputs to resolve or explicitly defer in the PR conversation.

--- a/docs/coderabbit/review-commands.md
+++ b/docs/coderabbit/review-commands.md
@@ -1,0 +1,17 @@
+# CodeRabbit Review Commands
+
+This file records the repository-canonical CodeRabbit commands used in LiteLLM PRs.
+
+## Commands
+
+- `@coderabbitai review` - request or resume review on the active PR.
+- `@coderabbitai full review` - request a fresh whole-PR review when incremental review is not enough.
+- `@coderabbitai pause` - pause automatic review on a noisy PR.
+- `@coderabbitai resume` - resume automatic review after a pause.
+
+## Repo Usage Notes
+
+- Put commands in PR comments, not commit messages.
+- Re-run `@coderabbitai review` after meaningful follow-up commits on the same PR.
+- Answer or resolve CodeRabbit findings that affect correctness, coverage, or PR scope before promoting the branch upstream.
+- Keep the PR body in sync with the current CI links and canonical issue while review is active.

--- a/docs/engineering/acceptance-criteria.md
+++ b/docs/engineering/acceptance-criteria.md
@@ -1,0 +1,35 @@
+# Engineering Acceptance Criteria
+
+This file is the repository-canonical completion checklist for focused engineering work.
+
+## General
+
+- A task is not done until code, focused tests, PR state, and linked issue state agree on the same outcome.
+- Follow existing LiteLLM patterns in `litellm/`, `tests/`, `.github/pull_request_template.md`, `AGENTS.md`, and `CLAUDE.md` instead of inventing a new delivery flow.
+- Keep issue-scoped fixes isolated. Unrelated cleanup stays out of the canonical PR unless it is required to unblock CI for that same branch.
+- New behavior must preserve backward compatibility unless the linked issue or PR explicitly calls for a breaking change.
+
+## Bug Fixes
+
+- Reproduce the reported failure with a focused regression test or equivalent CI-visible reproduction before changing production code.
+- Fix the root cause, not only the downstream symptom. If retries, fallbacks, or logging amplify the error, the original invalid input path still needs to fail fast.
+- For provider plus proxy bugs, verify both the provider-side path and the proxy ingress path when user input can reach both.
+- If malformed input should be rejected, return a user-facing validation error before transport dispatch whenever the code path allows it.
+
+## Tests
+
+- Add at least one test in `tests/test_litellm/` or the most specific existing test suite covering the changed behavior.
+- Keep the minimal focused verification command in the PR description and issue notes when the full repo suite is too large for quick iteration.
+- Run the targeted regression suite after each functional change and before creating or updating a PR.
+- If branch CI fails for a reason directly connected to the branch, fix that branch-level failure before opening or promoting the upstream PR.
+
+## PR And Issue State
+
+- Every fix branch must link to its canonical upstream issue in the PR body using `Fixes BerriAI/litellm#<issue>` when applicable.
+- The active PR must follow `.github/pull_request_template.md` and record the latest branch CI links and the current targeted verification evidence.
+- Resolve or explicitly answer AI review findings that question correctness, missing coverage, or unintended scope changes.
+- The linked upstream issue stays open until the canonical upstream PR exists or the fix is otherwise merged upstream.
+
+## Current Canonical Example
+
+- Issue `BerriAI/litellm#23959` is complete only when lone surrogate Unicode is rejected before Azure transport, proxy parsing rejects escaped lone surrogates, retry/fallback does not loop on the malformed request, branch CI is green, and an upstream PR exists.

--- a/docs/engineering/harness-engineering.md
+++ b/docs/engineering/harness-engineering.md
@@ -1,0 +1,28 @@
+# Harness Engineering
+
+This file records the repository-canonical verification commands for focused engineering work.
+
+## Baseline Commands
+
+- Full unit baseline: `make test-unit`
+- Fast lint baseline: `poetry run ruff check .`
+- Python script execution: `poetry run python <script>.py`
+- Proxy startup smoke: `poetry run litellm --config dev_config.yaml --port 4000`
+
+## Environment Notes
+
+- Some suites require extra local packages noted in `AGENTS.md`, including `psycopg-binary` and `openapi-core`.
+- The proxy boot path may need PostgreSQL or the default embedded Neon setup from `litellm-proxy-extras`.
+- CI is the final source of truth for broad suites when local environments are incomplete, but local targeted regressions should still run before PR updates.
+
+## Focused Verification For Issue 23959
+
+- Azure regression: `poetry run pytest tests/test_litellm/llms/azure/test_azure_exception_mapping.py -k surrogate -v`
+- Proxy parsing regression: `poetry run pytest tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py -k surrogate -v`
+- Router retry regression: `poetry run pytest tests/test_litellm/test_router_retry_non_retryable_errors.py -k surrogate -v`
+- Combined focused suite: `poetry run pytest tests/test_litellm/llms/azure/test_azure_exception_mapping.py tests/test_litellm/proxy/common_utils/test_http_parsing_utils.py tests/test_litellm/test_router_retry_non_retryable_errors.py -v`
+
+## Branch CI Handling
+
+- If a focused branch fails fork CI because of tests loaded from the same branch, fix the branch-level failure before opening the upstream PR.
+- Record the latest actionable workflow URL in the PR body after each rerun so reviewers can follow the canonical branch evidence.

--- a/docs/workflow/one-day-delivery-plan.md
+++ b/docs/workflow/one-day-delivery-plan.md
@@ -1,0 +1,26 @@
+# One-Day Delivery Plan
+
+This file defines the repository-canonical flow for a focused one-issue LiteLLM delivery.
+
+## Flow
+
+1. Confirm the canonical task from the user message, current branch, linked issue, and existing PR state.
+2. Reproduce the failure with a narrow regression test or CI-visible reproduction.
+3. Implement the minimal fix that follows existing LiteLLM patterns.
+4. Run the focused verification suite locally.
+5. Push the branch, update the fork PR body, and request AI review if available.
+6. Keep fixing branch-specific CI until the canonical fork PR is healthy.
+7. Open the upstream PR only after the fork PR is ready for maintainer review.
+
+## Branch Rules
+
+- Prefer one issue-scoped branch per canonical task, such as `fix-23959-azure-surrogate-local`.
+- Keep issue-fixing commits and branch-only test harness cleanup in separate commits when both are needed.
+- Reuse the same branch and PR instead of opening duplicates for the same issue.
+
+## Current Canonical Task
+
+- Canonical issue: `BerriAI/litellm#23959`
+- Active fork PR: `seonghobae/litellm#1`
+- Upstream PR: none yet
+- Required upstream promotion condition: branch PR evidence is ready and branch CI is healthy enough for maintainer review.

--- a/docs/workflow/pr-continuity.md
+++ b/docs/workflow/pr-continuity.md
@@ -1,0 +1,22 @@
+# PR Continuity
+
+This file defines the repository-canonical PR continuity rules for the current contribution flow.
+
+## Canonical PR Selection
+
+- Prefer the existing PR for the current branch over opening a new PR from the same head.
+- For fork-based work, the fork PR is canonical until an upstream PR is opened from the same branch head.
+- Always link the fork PR back to the upstream issue, not only to the fork repository.
+
+## Current Branch State
+
+- Branch: `fix-23959-azure-surrogate-local`
+- Canonical fork PR: `https://github.com/seonghobae/litellm/pull/1`
+- Canonical upstream issue: `https://github.com/BerriAI/litellm/issues/23959`
+- Upstream PR status: none yet
+
+## Promotion Rules
+
+- Update the existing fork PR body and checks instead of replacing it.
+- Open the upstream PR only after the fork PR state is coherent: linked issue, current CI links, latest commit pushed, and review findings addressed or answered.
+- Do not open a second upstream PR for the same branch head unless the first one is closed or superseded with explicit continuity notes.


### PR DESCRIPTION
## Relevant issues

Follow-up split from seonghobae/litellm#1 to keep docs changes separate from code fixes.

## Type

📚 Documentation

## Changes

- add canonical acceptance criteria for focused LiteLLM engineering work
- add harness, one-day delivery, PR continuity, agent, and CodeRabbit docs under `docs/`
- point `AGENTS.md` and `ARCHITECTURE.md` at the new canonical delivery docs
