### PR TITLE
fix: keep proxy model rotation JSON payloads plain

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3400,8 +3400,6 @@ async def _rotate_master_key(  # noqa: PLR0915
             )
             if new_model:
                 _dumped = new_model.model_dump(exclude_none=True)
-                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])  # type: ignore[attr-defined]
-                _dumped["model_info"] = prisma.Json(_dumped["model_info"])  # type: ignore[attr-defined]
                 new_models.append(_dumped)
         verbose_proxy_logger.debug("Resetting proxy model table")
         async with prisma_client.db.tx() as tx:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6487,15 +6487,15 @@ async def test_rotate_master_key_model_data_valid_for_prisma(
         "updated_at should be excluded so Prisma @default(now()) applies"
     )
 
-    # Verify litellm_params and model_info are prisma.Json wrappers, NOT JSON strings
-    import prisma
-
-    assert isinstance(model_data["litellm_params"], prisma.Json), (
-        f"litellm_params should be prisma.Json for create_many(), got {type(model_data['litellm_params'])}"
+    # Verify litellm_params and model_info stay as plain dicts for create_many
+    assert isinstance(model_data["litellm_params"], dict), (
+        f"litellm_params should be a dict for create_many(), got {type(model_data['litellm_params'])}"
     )
-    assert isinstance(model_data["model_info"], prisma.Json), (
-        f"model_info should be prisma.Json for create_many(), got {type(model_data['model_info'])}"
+    assert isinstance(model_data["model_info"], dict), (
+        f"model_info should be a dict for create_many(), got {type(model_data['model_info'])}"
     )
+    assert "model" in model_data["litellm_params"]
+    assert model_data["model_info"]["id"] == "model-1"
 
     # Verify delete_many was called inside the transaction (before create_many)
     mock_tx.litellm_proxymodeltable.delete_many.assert_called_once()


### PR DESCRIPTION
## Relevant issues

Follow-up split from seonghobae/litellm#1 to keep the Prisma `create_many()` master-key rotation failure isolated.

## Type

🐛 Bug Fix
✅ Test

## Changes

- stop wrapping rotated proxy model payloads with `prisma.Json` before `create_many()`
- keep the regression test aligned with the actual `create_many()` contract by asserting plain dict payloads

## Verification

- `poetry run pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k rotate_master_key_model_data_valid_for_prisma -vv` -> `1 passed`
