### PR TITLE
test: relax SAP credential header assertions

### DIFF
--- a/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -96,7 +96,7 @@ async def test_sap_chat(
         if sync_mode:
             response = litellm.completion(model=model, messages=messages)
         else:
-            response = await litellm.acompletion(model=model, messages=messages)
+            response = await litellm.acompletion(model=model, messages=messages, caching=False)
 
         assert response.choices[0].message.content == "Hello from SAP!"
         assert response.model.startswith("gpt-4o")
@@ -176,7 +176,7 @@ async def test_sap_chat_required_headers(
         route = respx_mock.post(f"{fake_deployment_url}/v2/completion")
         route.respond(json=sap_api_response)
 
-        response = await litellm.acompletion(model=model, messages=messages)
+        response = await litellm.acompletion(model=model, messages=messages, caching=False)
 
         # Verify the response is valid
         assert response.choices[0].message.content == "Hello from SAP!"

--- a/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -194,7 +194,10 @@ async def test_sap_chat_required_headers(
             if header_name in {"Authorization", "AI-Resource-Group"}:
                 assert request.headers[header_name]
                 if header_name == "Authorization":
-                    assert request.headers[header_name].startswith("Bearer ")
+                    parts = request.headers[header_name].split(" ")
+                    assert len(parts) == 2
+                    assert parts[0].lower() == "bearer"
+                    assert parts[1]
             else:
                 assert request.headers[header_name] == expected_value, (
                     f"Header '{header_name}' has incorrect value. "

--- a/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -79,19 +79,20 @@ async def test_sap_chat(
     import litellm
 
     litellm.disable_aiohttp_transport = True
-    with patch(
-        "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
-        new_callable=PropertyMock,
-        return_value=fake_deployment_url,
-    ), patch(
-        "litellm.llms.sap.chat.transformation.get_token_creator",
-        return_value=fake_token_creator,
+    with (
+        patch(
+            "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.chat.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
     ):
         model = "sap/gpt-4o"
         messages = [{"role": "user", "content": "Hello"}]
-        respx_mock.post(f"{fake_deployment_url}/v2/completion").respond(
-            json=sap_api_response
-        )
+        respx_mock.post(f"{fake_deployment_url}/v2/completion").respond(json=sap_api_response)
 
         if sync_mode:
             response = litellm.completion(model=model, messages=messages)
@@ -113,13 +114,16 @@ async def test_sap_streaming(
     import litellm
 
     litellm.disable_aiohttp_transport = True
-    with patch(
-        "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
-        new_callable=PropertyMock,
-        return_value=fake_deployment_url,
-    ), patch(
-        "litellm.llms.sap.chat.transformation.get_token_creator",
-        return_value=fake_token_creator,
+    with (
+        patch(
+            "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.chat.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
     ):
         model = "sap/gpt-4o"
         messages = [{"role": "user", "content": "Hello"}]
@@ -161,13 +165,16 @@ async def test_sap_chat_required_headers(
     }
 
     litellm.disable_aiohttp_transport = True
-    with patch(
-        "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
-        new_callable=PropertyMock,
-        return_value=fake_deployment_url,
-    ), patch(
-        "litellm.llms.sap.chat.transformation.get_token_creator",
-        return_value=fake_token_creator,
+    with (
+        patch(
+            "litellm.llms.sap.chat.transformation.GenAIHubOrchestrationConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.chat.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
     ):
         model = "sap/gpt-4o"
         messages = [{"role": "user", "content": "Hello"}]
@@ -188,16 +195,15 @@ async def test_sap_chat_required_headers(
         request = route.calls[0].request
         for header_name, expected_value in required_headers.items():
             assert header_name in request.headers, (
-                f"Required header '{header_name}' missing from request. "
-                f"Found headers: {list(request.headers.keys())}"
+                f"Required header '{header_name}' missing from request. Found headers: {list(request.headers.keys())}"
             )
             if header_name in {"Authorization", "AI-Resource-Group"}:
-                assert request.headers[header_name]
+                assert request.headers[header_name].strip()
                 if header_name == "Authorization":
-                    parts = request.headers[header_name].split(" ")
+                    parts = request.headers[header_name].strip().split(None, 1)
                     assert len(parts) == 2
                     assert parts[0].lower() == "bearer"
-                    assert parts[1]
+                    assert parts[1].strip(), "Authorization token must not be empty"
             else:
                 assert request.headers[header_name] == expected_value, (
                     f"Header '{header_name}' has incorrect value. "

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1601,7 +1601,7 @@ async def test_sap_chat(
         if sync_mode:
             response = litellm.embedding(model=model, input=input)
         else:
-            response = await litellm.aembedding(model=model, input=input)
+            response = await litellm.aembedding(model=model, input=input, caching=False)
 
         assert response
         assert response.data[0]["embedding"]

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1641,7 +1641,7 @@ async def test_sap_embedding_required_headers(
         route = respx_mock.post(f"{fake_deployment_url}/v2/embeddings")
         route.respond(json=sap_api_response)
 
-        response = await litellm.aembedding(model=model, input=input)
+        response = await litellm.aembedding(model=model, input=input, caching=False)
 
         # Verify the response is valid
         assert response

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1583,19 +1583,20 @@ async def test_sap_chat(
     import litellm
 
     litellm.disable_aiohttp_transport = True
-    with patch(
-        "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
-        new_callable=PropertyMock,
-        return_value=fake_deployment_url,
-    ), patch(
-        "litellm.llms.sap.embed.transformation.get_token_creator",
-        return_value=fake_token_creator,
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
     ):
         model = "sap/text-embedding-3-small"
         input = "Hi"
-        respx_mock.post(f"{fake_deployment_url}/v2/embeddings").respond(
-            json=sap_api_response
-        )
+        respx_mock.post(f"{fake_deployment_url}/v2/embeddings").respond(json=sap_api_response)
 
         if sync_mode:
             response = litellm.embedding(model=model, input=input)
@@ -1625,13 +1626,16 @@ async def test_sap_embedding_required_headers(
     }
 
     litellm.disable_aiohttp_transport = True
-    with patch(
-        "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
-        new_callable=PropertyMock,
-        return_value=fake_deployment_url,
-    ), patch(
-        "litellm.llms.sap.embed.transformation.get_token_creator",
-        return_value=fake_token_creator,
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
     ):
         model = "sap/text-embedding-3-small"
         input = "Hi"
@@ -1653,16 +1657,15 @@ async def test_sap_embedding_required_headers(
         request = route.calls[0].request
         for header_name, expected_value in required_headers.items():
             assert header_name in request.headers, (
-                f"Required header '{header_name}' missing from request. "
-                f"Found headers: {list(request.headers.keys())}"
+                f"Required header '{header_name}' missing from request. Found headers: {list(request.headers.keys())}"
             )
             if header_name in {"Authorization", "AI-Resource-Group"}:
-                assert request.headers[header_name]
+                assert request.headers[header_name].strip()
                 if header_name == "Authorization":
-                    parts = request.headers[header_name].split(" ")
+                    parts = request.headers[header_name].strip().split(None, 1)
                     assert len(parts) == 2
                     assert parts[0].lower() == "bearer"
-                    assert parts[1]
+                    assert parts[1].strip(), "Authorization token must not be empty"
             else:
                 assert request.headers[header_name] == expected_value, (
                     f"Header '{header_name}' has incorrect value. "

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1,4 +1,3 @@
-import httpx
 from unittest.mock import patch, PropertyMock
 
 import pytest
@@ -1660,7 +1659,10 @@ async def test_sap_embedding_required_headers(
             if header_name in {"Authorization", "AI-Resource-Group"}:
                 assert request.headers[header_name]
                 if header_name == "Authorization":
-                    assert request.headers[header_name].startswith("Bearer ")
+                    parts = request.headers[header_name].split(" ")
+                    assert len(parts) == 2
+                    assert parts[0].lower() == "bearer"
+                    assert parts[1]
             else:
                 assert request.headers[header_name] == expected_value, (
                     f"Header '{header_name}' has incorrect value. "

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -62,12 +62,8 @@ def _make_prisma(
     prisma = MagicMock()
     prisma.db.litellm_tooltable = MagicMock()
     prisma.db.litellm_tooltable.upsert = AsyncMock(return_value=upsert_return)
-    prisma.db.litellm_tooltable.find_many = AsyncMock(
-        return_value=find_many_rows if find_many_rows is not None else []
-    )
-    prisma.db.litellm_tooltable.find_unique = AsyncMock(
-        return_value=find_unique_row
-    )
+    prisma.db.litellm_tooltable.find_many = AsyncMock(return_value=find_many_rows if find_many_rows is not None else [])
+    prisma.db.litellm_tooltable.find_unique = AsyncMock(return_value=find_unique_row)
     return prisma
 
 
@@ -163,9 +159,7 @@ async def test_get_tool_found():
     result = await get_tool(prisma, "my_tool")
     assert result is not None
     assert result.tool_name == "my_tool"
-    prisma.db.litellm_tooltable.find_unique.assert_awaited_once_with(
-        where={"tool_name": "my_tool"}
-    )
+    prisma.db.litellm_tooltable.find_unique.assert_awaited_once_with(where={"tool_name": "my_tool"})
 
 
 @pytest.mark.asyncio
@@ -184,9 +178,7 @@ async def test_update_tool_policy_calls_upsert_then_get_tool():
         updated_by="admin",
     )
     prisma = _make_prisma(find_unique_row=row)
-    result = await update_tool_policy(
-        prisma, "my_tool", updated_by="admin", input_policy="blocked"
-    )
+    result = await update_tool_policy(prisma, "my_tool", updated_by="admin", input_policy="blocked")
     assert result is not None
     assert result.input_policy == "blocked"
     prisma.db.litellm_tooltable.upsert.assert_awaited_once()
@@ -194,9 +186,7 @@ async def test_update_tool_policy_calls_upsert_then_get_tool():
     assert call_kw["where"] == {"tool_name": "my_tool"}
     assert call_kw["data"]["update"]["input_policy"] == "blocked"
     assert call_kw["data"]["update"]["updated_by"] == "admin"
-    prisma.db.litellm_tooltable.find_unique.assert_awaited_with(
-        where={"tool_name": "my_tool"}
-    )
+    prisma.db.litellm_tooltable.find_unique.assert_awaited_with(where={"tool_name": "my_tool"})
 
 
 @pytest.mark.asyncio
@@ -211,9 +201,7 @@ async def test_get_tools_by_names_returns_policy_map():
         "tool_a": ("trusted", "untrusted"),
         "tool_b": ("blocked", "untrusted"),
     }
-    prisma.db.litellm_tooltable.find_many.assert_awaited_once_with(
-        where={"tool_name": {"in": ["tool_a", "tool_b"]}}
-    )
+    prisma.db.litellm_tooltable.find_many.assert_awaited_once_with(where={"tool_name": {"in": ["tool_a", "tool_b"]}})
 
 
 @pytest.mark.asyncio
@@ -263,7 +251,7 @@ async def test_tool_policy_registry_sync_and_get_effective_policies():
             _mock_perm_row("op-team-1", ["tool_c"]),
         ]
     )
-    registry = get_tool_policy_registry()
+    registry = ToolPolicyRegistry()
     await registry.sync_tool_policy_from_db(prisma)
     assert registry.is_initialized()
     # Key blocked: tool_a. Team blocked: tool_c. Global: tool_b blocked.

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -186,7 +186,7 @@ async def test_update_tool_policy_calls_upsert_then_get_tool():
     assert call_kw["where"] == {"tool_name": "my_tool"}
     assert call_kw["data"]["update"]["input_policy"] == "blocked"
     assert call_kw["data"]["update"]["updated_by"] == "admin"
-    prisma.db.litellm_tooltable.find_unique.assert_awaited_with(where={"tool_name": "my_tool"})
+    prisma.db.litellm_tooltable.find_unique.assert_awaited_once_with(where={"tool_name": "my_tool"})
 
 
 @pytest.mark.asyncio
@@ -277,3 +277,10 @@ async def test_tool_policy_registry_not_initialized_returns_untrusted():
     assert not registry.is_initialized()
     result = registry.get_effective_policies(["unknown_tool"])
     assert result == {"unknown_tool": "untrusted"}
+
+
+def test_get_tool_policy_registry_singleton():
+    """get_tool_policy_registry should return the same singleton instance across calls."""
+    registry1 = get_tool_policy_registry()
+    registry2 = get_tool_policy_registry()
+    assert registry1 is registry2

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -279,8 +279,9 @@ async def test_tool_policy_registry_not_initialized_returns_untrusted():
     assert result == {"unknown_tool": "untrusted"}
 
 
-def test_get_tool_policy_registry_singleton():
+def test_get_tool_policy_registry_singleton(monkeypatch):
     """get_tool_policy_registry should return the same singleton instance across calls."""
+    monkeypatch.setattr("litellm.proxy.db.tool_registry_writer._tool_policy_registry", None)
     registry1 = get_tool_policy_registry()
     registry2 = get_tool_policy_registry()
     assert registry1 is registry2


### PR DESCRIPTION
## Relevant issues

Follow-up split from seonghobae/litellm#1 to keep the SAP header assertion brittleness separate.

## Stack

- base branch: `test-ui-sso-pkce-warning-capture`
- keeps SAP header assertions stable before the OpenAPI and issue branches on top

## Type

✅ Test

## Changes

- keep exact assertions for stable SAP headers
- relax credential-derived SAP headers to behavior checks so the tests do not depend on exact mock token/resource values
- disable caching in the SAP header assertion tests so the respx request route is exercised deterministically
- explicitly disable caching in the SAP embed header assertion that still hit a cached response under full-suite execution

## Verification

- `poetry run pytest tests/test_litellm/llms/sap/chat/test_sap_chat_calls.py -k required_headers -vv` -> `1 passed`
- `poetry run pytest tests/test_litellm/llms/sap/embed/test_sap_embedding.py -k required_headers -vv` -> `1 passed`
