### PR TITLE
fix: fall back when remote image fetch fails

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -216,9 +216,12 @@ def get_image_dimensions(
         response = client.get(data)
         img_data = response.read()
     except Exception:
-        # If not URL, assume it's base64
-        _header, encoded = data.split(",", 1)
-        img_data = base64.b64decode(encoded)
+        # If not URL, only decode data URIs as base64.
+        if data.startswith("data:") and "," in data:
+            _header, encoded = data.split(",", 1)
+            img_data = base64.b64decode(encoded)
+        else:
+            return DEFAULT_IMAGE_WIDTH, DEFAULT_IMAGE_HEIGHT
 
     img_type = get_image_type(img_data)
 


### PR DESCRIPTION
## Relevant issues

Follow-up split from seonghobae/litellm#1 to keep the token-counter remote image fallback fix separate.

## Type

🐛 Bug Fix
✅ Test

## Changes

- only decode base64 for data URIs in `get_image_dimensions()`
- return the default dimensions when a remote image fetch fails for a normal URL

## Verification

- `poetry run pytest tests/test_litellm/litellm_core_utils/test_token_counter.py -k img_url_token_counter -vv` -> `2 passed`
