### PR TITLE
test: pass explicit client to watsonx transcription mocks

### DIFF
--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -4,10 +4,9 @@ Tests for IBM WatsonX Audio Transcription.
 Validates that litellm.transcription transforms requests correctly for WatsonX.
 """
 
-import json
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -31,8 +30,6 @@ class TestWatsonXAudioTranscription:
         captured_request = {}
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-        client = AsyncHTTPHandler()
-
         async def mock_post(*args, **kwargs):
             captured_request["url"] = str(kwargs.get("url", args[0] if args else None))
             captured_request["headers"] = kwargs.get("headers", {})
@@ -51,6 +48,7 @@ class TestWatsonXAudioTranscription:
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
             new=mock_post,
         ):
+            client = AsyncHTTPHandler()
             try:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
@@ -63,6 +61,8 @@ class TestWatsonXAudioTranscription:
                 )
             except Exception:
                 pass  # We just want to capture the request
+            finally:
+                await client.close()
 
         # Validate URL contains WatsonX audio transcription endpoint
         assert "/ml/v1/audio/transcriptions" in captured_request["url"]
@@ -98,8 +98,6 @@ class TestWatsonXAudioTranscription:
         captured_request = {}
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-        client = AsyncHTTPHandler()
-
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
             captured_request["files"] = kwargs.get("files", {})
@@ -116,6 +114,7 @@ class TestWatsonXAudioTranscription:
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
             new=mock_post,
         ):
+            client = AsyncHTTPHandler()
             try:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
@@ -130,12 +129,11 @@ class TestWatsonXAudioTranscription:
                 )
             except Exception:
                 pass  # We just want to capture the request
+            finally:
+                await client.close()
 
         # Validate form data contains expected fields
         data = captured_request.get("data", {})
-
-        print("JSON DUMPS captured_request:")
-        print(json.dumps(captured_request, indent=4, default=str))
 
         # Model name should NOT have watsonx/ prefix
         assert data.get("model") == "whisper-large-v3-turbo"
@@ -164,8 +162,6 @@ class TestWatsonXAudioTranscription:
         captured_request = {}
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-        client = AsyncHTTPHandler()
-
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
             captured_request["files"] = kwargs.get("files", {})
@@ -182,6 +178,7 @@ class TestWatsonXAudioTranscription:
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
             new=mock_post,
         ):
+            client = AsyncHTTPHandler()
             try:
                 # Minimal request - only required params
                 await litellm.atranscription(
@@ -195,6 +192,8 @@ class TestWatsonXAudioTranscription:
                 )
             except Exception:
                 pass  # We just want to capture the request
+            finally:
+                await client.close()
 
         data = captured_request.get("data", {})
 
@@ -225,8 +224,6 @@ class TestWatsonXAudioTranscription:
         captured_request = {}
         from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-        client = AsyncHTTPHandler()
-
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
             captured_request["files"] = kwargs.get("files", {})
@@ -243,6 +240,7 @@ class TestWatsonXAudioTranscription:
             "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
             new=mock_post,
         ):
+            client = AsyncHTTPHandler()
             try:
                 # Minimal request - only required params
                 await litellm.atranscription(
@@ -256,6 +254,8 @@ class TestWatsonXAudioTranscription:
                 )
             except Exception:
                 pass  # We just want to capture the request
+            finally:
+                await client.close()
 
         data = captured_request.get("data", {})
 

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -29,6 +29,9 @@ class TestWatsonXAudioTranscription:
         Test that litellm.transcription sends request to correct WatsonX URL with proper headers.
         """
         captured_request = {}
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        client = AsyncHTTPHandler()
 
         async def mock_post(*args, **kwargs):
             captured_request["url"] = str(kwargs.get("url", args[0] if args else None))
@@ -52,6 +55,7 @@ class TestWatsonXAudioTranscription:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
                     file=b"fake_audio_data",
+                    client=client,
                     api_base="https://us-south.ml.cloud.ibm.com",
                     api_key="test-api-key",
                     project_id="test-project-123",
@@ -68,9 +72,7 @@ class TestWatsonXAudioTranscription:
 
         # Validate headers contain WatsonX auth
         assert "Authorization" in captured_request["headers"]
-        assert (
-            "Bearer test-bearer-token" in captured_request["headers"]["Authorization"]
-        )
+        assert "Bearer test-bearer-token" in captured_request["headers"]["Authorization"]
 
         # Validate Content-Type is NOT set (httpx sets multipart/form-data automatically)
         assert "Content-Type" not in captured_request["headers"]
@@ -94,6 +96,9 @@ class TestWatsonXAudioTranscription:
         - OpenAI params are included in form data
         """
         captured_request = {}
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        client = AsyncHTTPHandler()
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
@@ -115,6 +120,7 @@ class TestWatsonXAudioTranscription:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
                     file=b"fake_audio_data",
+                    client=client,
                     api_base="https://us-south.ml.cloud.ibm.com",
                     api_key="test-api-key",
                     project_id="test-project-123",
@@ -146,9 +152,7 @@ class TestWatsonXAudioTranscription:
         # Validate file is in files dict (multipart/form-data)
         files = captured_request.get("files", {})
         assert "file" in files
-        assert isinstance(
-            files["file"], tuple
-        )  # Should be (filename, content, content_type)
+        assert isinstance(files["file"], tuple)  # Should be (filename, content, content_type)
 
     @pytest.mark.asyncio
     async def test_watsonx_transcription_only_user_params_sent_with_project_id(self):
@@ -158,6 +162,9 @@ class TestWatsonXAudioTranscription:
         LiteLLM should NOT add extra params like response_format if user didn't specify them.
         """
         captured_request = {}
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        client = AsyncHTTPHandler()
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
@@ -180,6 +187,7 @@ class TestWatsonXAudioTranscription:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
                     file=b"fake_audio_data",
+                    client=client,
                     api_base="https://us-south.ml.cloud.ibm.com",
                     api_key="test-api-key",
                     project_id="test-project-123",
@@ -201,9 +209,7 @@ class TestWatsonXAudioTranscription:
         )
 
         # Specifically verify response_format is NOT added
-        assert (
-            "response_format" not in data
-        ), "response_format should NOT be added by default"
+        assert "response_format" not in data, "response_format should NOT be added by default"
 
         # Verify file is sent separately
         files = captured_request.get("files", {})
@@ -217,6 +223,9 @@ class TestWatsonXAudioTranscription:
         LiteLLM should NOT add extra params like response_format if user didn't specify them.
         """
         captured_request = {}
+        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+        client = AsyncHTTPHandler()
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
@@ -239,6 +248,7 @@ class TestWatsonXAudioTranscription:
                 await litellm.atranscription(
                     model="watsonx/whisper-large-v3-turbo",
                     file=b"fake_audio_data",
+                    client=client,
                     api_base="https://us-south.ml.cloud.ibm.com",
                     api_key="test-api-key",
                     space_id="test-space_id-123",
@@ -260,9 +270,7 @@ class TestWatsonXAudioTranscription:
         )
 
         # Specifically verify response_format is NOT added
-        assert (
-            "response_format" not in data
-        ), "response_format should NOT be added by default"
+        assert "response_format" not in data, "response_format should NOT be added by default"
 
         # Verify file is sent separately
         files = captured_request.get("files", {})
@@ -286,7 +294,9 @@ class TestWatsonXAudioTranscription:
             "model": "whisper-large-v3-turbo",  # This field should be removed
             "duration": 5.5,
         }
-        mock_response.text = '{"text": "Hello, this is a test transcription.", "model": "whisper-large-v3-turbo", "duration": 5.5}'
+        mock_response.text = (
+            '{"text": "Hello, this is a test transcription.", "model": "whisper-large-v3-turbo", "duration": 5.5}'
+        )
 
         # This should not raise a TypeError - model field should be removed
         result = handler.transform_audio_transcription_response(mock_response)
@@ -324,9 +334,7 @@ class TestWatsonXAudioTranscription:
             "text": "Hello, this is a test transcription.",
             "duration": 5.5,
         }
-        mock_response.text = (
-            '{"text": "Hello, this is a test transcription.", "duration": 5.5}'
-        )
+        mock_response.text = '{"text": "Hello, this is a test transcription.", "duration": 5.5}'
 
         result = handler.transform_audio_transcription_response(mock_response)
 

--- a/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
 import litellm
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.llms.watsonx.audio_transcription.transformation import (
     IBMWatsonXAudioTranscriptionConfig,
 )
@@ -28,7 +29,6 @@ class TestWatsonXAudioTranscription:
         Test that litellm.transcription sends request to correct WatsonX URL with proper headers.
         """
         captured_request = {}
-        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
         async def mock_post(*args, **kwargs):
             captured_request["url"] = str(kwargs.get("url", args[0] if args else None))
@@ -96,7 +96,6 @@ class TestWatsonXAudioTranscription:
         - OpenAI params are included in form data
         """
         captured_request = {}
-        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
@@ -160,7 +159,6 @@ class TestWatsonXAudioTranscription:
         LiteLLM should NOT add extra params like response_format if user didn't specify them.
         """
         captured_request = {}
-        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})
@@ -222,7 +220,6 @@ class TestWatsonXAudioTranscription:
         LiteLLM should NOT add extra params like response_format if user didn't specify them.
         """
         captured_request = {}
-        from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
         async def mock_post(*args, **kwargs):
             captured_request["data"] = kwargs.get("data", {})


### PR DESCRIPTION
## Relevant issues

Follow-up split from seonghobae/litellm#1 to keep the Watsonx transcription test seam fix separate.

## Type

✅ Test

## Changes

- instantiate an `AsyncHTTPHandler` in the Watsonx transcription tests
- pass `client=client` into `litellm.atranscription(...)` so the mocked async post seam is the one actually used

## Verification

- `poetry run pytest tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py -vv` -> `6 passed`

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>

## 개요

Watson X 오디오 전사 변환 테스트에 AsyncHTTPHandler 클라이언트를 주입하고, 어설션 형식을 단순화하며, 모의 응답 텍스트 할당의 서식을 조정했습니다.

## 변경 사항

|코호트 / 파일(들)|요약|
|---|---|
|**테스트 설정 및 어설션 개선** <br> `tests/test_litellm/llms/watsonx/audio_transcription/test_watsonx_audio_transcription_transformation.py`|여러 `litellm.atranscription()` 호출에 `AsyncHTTPHandler` 인스턴스를 `client=client` 인수로 주입하고, 다중 행 형식을 제거하여 어설션을 단순화했으며, 모의 응답 텍스트 문자열 할당의 서식을 조정했습니다.|

## 예상 코드 리뷰 난이도

🎯 2 (Simple) | ⏱️ ~10 분

## 시

> 🐰 테스트가 부릅고 또 부르길래  
> HTTP 클라이언트를 쏙 넣어주고  
> 어설션도 반짝반짝 정리했네!  
> 모의 데이터 옷도 갈아입혀  
> 전사 요청 이제 더 깔끔하게 흘러가네 ✨

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->